### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run pre-commit (ruff + black + mypy + basic hooks)
+        uses: pre-commit/action@v3.0.1
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        run: |
+          pipx install poetry
+          poetry config virtualenvs.in-project true
+
+      # poetry.lock is gitignored in this project, so key the cache off
+      # pyproject.toml (and the lock if one happens to be present).
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+
+      - name: Install dependencies
+        run: |
+          poetry env use "${{ matrix.python-version }}"
+          poetry install --no-interaction
+
+      - name: Run tests
+        run: poetry run pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.egg-info/
 .venv/
 venv/
+.testvenv/
 dist/
 build/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Run locally with: pre-commit install  (then hooks run on every `git commit`)
+# Run across the whole tree with: pre-commit run --all-files
+# CI runs the same hooks via the `lint` job in .github/workflows/ci.yml.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.1
+    hooks:
+      - id: mypy
+        files: ^src/
+        # Match the project's real type environment so results are identical to
+        # `poetry run mypy src`. (qtics ships no stubs → ignore_missing_imports.)
+        additional_dependencies:
+          - pydantic>=2.7
+          - pydantic-settings>=2.3
+          - discord.py>=2.4.0
+          - aiohttp>=3.9
+          - types-PyYAML

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ dilution refrigerators — **Elsa**, **Anna**, and **Olaf**.
   thread where the command is invoked, by reverse-lookup of the
   `<FRIDGE>_DESTINATION_ID` values in `.env`. Invoking `/report` outside any
   configured channel is silently ignored (logged for audit).
-- **Daily 09:30** — automatic report per fridge, posted only when the fridge is
-  active (status not `Idle`) and the mixing-chamber temperature is in scale
-  (not exactly `0`).
+- **Daily 09:30** — automatic report per fridge, skipped only when the fridge is
+  in LOCAL mode, or when it is `Idle` **and** warm (Pulse-tube 2 above 273 K).
 - Units **auto-scale by magnitude**: 0.9 K → `900 mK`; 1.2 nW heater → `1.2 nW`;
   1500 Pa → `1.5 kPa`. Flow shown as μmol/s.
 - Sends to a **thread** or **channel** (per fridge, configured in `.env`).
@@ -125,7 +124,7 @@ resources:
 `uri_key` must match a key in the qtics `getters` dict (defined in
 `qtics/instruments/network/proteox/uris.py`). The bot calls `get_<uri_key>()`
 which is dynamically created by qtics's `__getattr__`. Valid keys include:
-`MC_T`, `STILL_T`, `CP_T`, `PT1_T`, `PT2_T`, `MAG_T`, `SRB_T`, `OVC_P`, 
+`MC_T`, `STILL_T`, `CP_T`, `PT1_T`, `PT2_T`, `MAG_T`, `SRB_T`, `OVC_P`,
 `P1_P`–`P6_P`, `MC_H`, `STILL_H`, `3He_F`, etc. Add/remove rows freely — the
 report adjusts automatically.
 
@@ -171,3 +170,34 @@ For each fridge at 09:30:
 4. Otherwise, build a personalized embed and post to the fridge's destination.
 
 `/report` runs the same pipeline but never skips — it always returns something.
+
+## Contributing
+
+`main` is protected: changes land only through a pull request that passes
+**review** and **CI**. Direct pushes to `main` are rejected.
+
+Workflow:
+
+1. Branch off `main`, make your change.
+2. Run the checks locally (see below) and push the branch.
+3. Open a PR into `main`. CI runs automatically.
+4. A PR can be merged once it has **1 approving review** and all checks are green
+   (`lint`, `test (3.11)`, `test (3.12)`).
+
+### Local checks
+
+```bash
+poetry install            # includes dev tools (black, ruff, mypy, pytest, pre-commit)
+poetry run pre-commit install   # one-time: run the hooks on every commit
+```
+
+The hooks (and CI's `lint` job) run **ruff** (lint), **black** (format), and
+**mypy** (types). Run them on demand with:
+
+```bash
+poetry run pre-commit run --all-files   # ruff + black + mypy + misc hooks
+poetry run pytest                       # the test suite
+```
+
+CI mirrors this exactly: a `lint` job (pre-commit) plus a `test` job across
+Python 3.11 and 3.12.

--- a/config/anna.yaml
+++ b/config/anna.yaml
@@ -26,4 +26,3 @@ resources:
   - { label: "Grafana", url: "http://anna.mib.infn.it:3000/d/2RmbBORRz/temperature-overview" }
   - { label: "Logbook", url: "https://docs.google.com/spreadsheets/d/1GRVGGq3Nh9QnF2wynZf1tApzgfahYQwuC7tu1oaOyu8/edit?gid=0#gid=0" }
   - { label: "Wiki", url: "https://holmes0.mib.infn.it/marewiki/!qtmibwiki/home" }
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ h5py = ">=3.10"
 pytest = "^8.2"
 pytest-asyncio = "^0.23"
 ruff = "^0.5"
+black = "^24.4"
+mypy = "^1.10"
+pre-commit = "^3.7"
 
 [tool.poetry.scripts]
 qubot = "qubot.main:run"
@@ -28,6 +31,21 @@ qubot = "qubot.main:run"
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.mypy]
+python_version = "3.11"
+files = ["src"]
+# The codebase was not previously type-checked and pulls in untyped third-party
+# packages (qtics, aiohttp internals). Stay pragmatic rather than --strict so a
+# flood of errors doesn't block every PR; tighten incrementally over time.
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+no_implicit_optional = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/qubot/cogs/help.py
+++ b/src/qubot/cogs/help.py
@@ -33,10 +33,7 @@ def _build_help_embed() -> discord.Embed:
     )
     embed.add_field(
         name="**Everywhere**",
-        value=(
-            "`/uta` — HVAC plant (UTA) status report.\n"
-            "`/help` — this message."
-        ),
+        value=("`/uta` — HVAC plant (UTA) status report.\n" "`/help` — this message."),
         inline=False,
     )
     embed.add_field(
@@ -57,9 +54,7 @@ class HelpCog(commands.Cog):
 
     @app_commands.command(name="help", description="Show available QuBot commands.")
     async def help_cmd(self, interaction: discord.Interaction) -> None:
-        self.log.info(
-            "/help invoked by %s in channel=%s", interaction.user, interaction.channel_id
-        )
+        self.log.info("/help invoked by %s in channel=%s", interaction.user, interaction.channel_id)
         await interaction.response.defer(thinking=True)
         await interaction.followup.send(embed=_build_help_embed())
 

--- a/src/qubot/cogs/monday.py
+++ b/src/qubot/cogs/monday.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, time, timezone
+from datetime import datetime, time
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 

--- a/src/qubot/cogs/reports.py
+++ b/src/qubot/cogs/reports.py
@@ -28,8 +28,7 @@ class ReportsCog(commands.Cog):
         self.log = get_logger("cog.reports")
         # Reverse-lookup: which fridge owns a given channel/thread ID?
         self._fridge_by_channel: dict[int, str] = {
-            conn.destination_id: name
-            for name, conn in bot.settings.fridges.items()
+            conn.destination_id: name for name, conn in bot.settings.fridges.items()
         }
         self.log.info(
             "channel→fridge map: %s",
@@ -39,7 +38,9 @@ class ReportsCog(commands.Cog):
     @app_commands.command(name="report", description="Generate a fridge report for this channel.")
     async def report(self, interaction: discord.Interaction) -> None:
         channel_id = interaction.channel_id
-        name = self._fridge_by_channel.get(channel_id)
+        # channel_id is None in DMs; .get tolerates it and the None branch below
+        # handles unbound/DM channels identically.
+        name = self._fridge_by_channel.get(channel_id)  # type: ignore[arg-type]
         if name is None:
             self.log.info(
                 "/report ignored: channel %s not bound to a fridge (user=%s)",
@@ -62,9 +63,7 @@ class ReportsCog(commands.Cog):
         except RuntimeError as exc:
             # Timeout or connection error from ProteoxService
             self.log.error("service error for %s: %s", name, exc)
-            await interaction.followup.send(
-                f":warning: **{profile.display_name}** {exc}"
-            )
+            await interaction.followup.send(f":warning: **{profile.display_name}** {exc}")
             return
         except Exception as exc:  # noqa: BLE001
             self.log.exception("snapshot failed for %s", name)

--- a/src/qubot/cogs/scheduler.py
+++ b/src/qubot/cogs/scheduler.py
@@ -73,7 +73,8 @@ class SchedulerCog(commands.Cog):
         if snap.is_idle and pt2 is not None and pt2 > 273:
             self.log.info(
                 "skip %s: warm (idle and PT2=%.2f K > 273 K)",
-                name, pt2,
+                name,
+                pt2,
             )
             return
 

--- a/src/qubot/cogs/states.py
+++ b/src/qubot/cogs/states.py
@@ -30,14 +30,15 @@ class StatesCog(commands.Cog):
         self.bot = bot
         self.log = get_logger("cog.states")
         self._fridge_by_channel: dict[int, str] = {
-            conn.destination_id: name
-            for name, conn in bot.settings.fridges.items()
+            conn.destination_id: name for name, conn in bot.settings.fridges.items()
         }
 
     async def _silently_ignore(self, interaction: discord.Interaction, cmd: str) -> None:
         self.log.info(
             "/%s ignored: channel %s not bound to a fridge (user=%s)",
-            cmd, interaction.channel_id, interaction.user,
+            cmd,
+            interaction.channel_id,
+            interaction.user,
         )
         await interaction.response.defer(ephemeral=True)
 
@@ -46,7 +47,9 @@ class StatesCog(commands.Cog):
         description="List recognized cryostat states for this channel's fridge.",
     )
     async def recognizedstates(self, interaction: discord.Interaction) -> None:
-        name = self._fridge_by_channel.get(interaction.channel_id)
+        # channel_id is None in DMs; .get tolerates it and the None branch below
+        # handles unbound/DM channels identically.
+        name = self._fridge_by_channel.get(interaction.channel_id)  # type: ignore[arg-type]
         if name is None:
             await self._silently_ignore(interaction, "recognizedstates")
             return
@@ -60,7 +63,9 @@ class StatesCog(commands.Cog):
         description="Check whether the cryostat is in a recognized state.",
     )
     async def recognized(self, interaction: discord.Interaction) -> None:
-        name = self._fridge_by_channel.get(interaction.channel_id)
+        # channel_id is None in DMs; .get tolerates it and the None branch below
+        # handles unbound/DM channels identically.
+        name = self._fridge_by_channel.get(interaction.channel_id)  # type: ignore[arg-type]
         if name is None:
             await self._silently_ignore(interaction, "recognized")
             return
@@ -75,9 +80,7 @@ class StatesCog(commands.Cog):
                 result = await svc.recognized_status()
         except RuntimeError as exc:
             self.log.error("service error for %s: %s", name, exc)
-            await interaction.followup.send(
-                f":warning: **{profile.display_name}** {exc}"
-            )
+            await interaction.followup.send(f":warning: **{profile.display_name}** {exc}")
             return
         except Exception as exc:  # noqa: BLE001
             self.log.exception("recognized check failed for %s", name)
@@ -111,14 +114,18 @@ class StatesCog(commands.Cog):
         interaction: discord.Interaction,
         target_state: str | None = None,
     ) -> None:
-        name = self._fridge_by_channel.get(interaction.channel_id)
+        # channel_id is None in DMs; .get tolerates it and the None branch below
+        # handles unbound/DM channels identically.
+        name = self._fridge_by_channel.get(interaction.channel_id)  # type: ignore[arg-type]
         if name is None:
             await self._silently_ignore(interaction, "howto")
             return
 
         self.log.info(
             "/howto invoked by %s for fridge=%s target=%r",
-            interaction.user, name, target_state,
+            interaction.user,
+            name,
+            target_state,
         )
         await interaction.response.defer(thinking=True)
 
@@ -129,9 +136,7 @@ class StatesCog(commands.Cog):
                 plan = await svc.transition_plan(target_state)
         except RuntimeError as exc:
             self.log.error("service error for %s: %s", name, exc)
-            await interaction.followup.send(
-                f":warning: **{profile.display_name}** {exc}"
-            )
+            await interaction.followup.send(f":warning: **{profile.display_name}** {exc}")
             return
         except Exception as exc:  # noqa: BLE001
             self.log.exception("transition plan failed for %s", name)

--- a/src/qubot/cogs/uta.py
+++ b/src/qubot/cogs/uta.py
@@ -29,9 +29,7 @@ class UtaCog(commands.Cog):
 
     @app_commands.command(name="uta", description="Show UTA (HVAC) status report.")
     async def uta(self, interaction: discord.Interaction) -> None:
-        self.log.info(
-            "/uta invoked by %s in channel=%s", interaction.user, interaction.channel_id
-        )
+        self.log.info("/uta invoked by %s in channel=%s", interaction.user, interaction.channel_id)
         await interaction.response.defer(thinking=True)
         try:
             snap = await fetch_uta_snapshot(self.bot.settings)

--- a/src/qubot/core/fridge_config.py
+++ b/src/qubot/core/fridge_config.py
@@ -67,9 +67,9 @@ class FridgeProfile(BaseModel):
         so callers can decide whether to render them."""
         return [
             ("Temperatures", self.temperatures),
-            ("Pressures",    self.pressures),
-            ("Heaters",      self.heaters),
-            ("Flow",         self.flow),
+            ("Pressures", self.pressures),
+            ("Heaters", self.heaters),
+            ("Flow", self.flow),
         ]
 
     def has_resources(self) -> bool:

--- a/src/qubot/core/settings.py
+++ b/src/qubot/core/settings.py
@@ -76,7 +76,10 @@ class Settings(BaseSettings):
         so the bot can start with only a subset configured.
         """
         import logging
-        base = cls()
+
+        # Required fields (discord_token, wamp_user, ...) are populated from the
+        # environment by pydantic-settings, which mypy cannot infer statically.
+        base = cls()  # type: ignore[call-arg]
         for name in FRIDGE_NAMES:
             try:
                 base.fridges[name] = FridgeConnection(_env_prefix=f"{name.upper()}_")  # type: ignore[call-arg]
@@ -85,5 +88,7 @@ class Settings(BaseSettings):
                     "skipping fridge %s — incomplete config: %s", name, exc
                 )
         if not base.fridges:
-            raise RuntimeError("No fridges configured — set at least one <FRIDGE>_PROTEOX_URL and <FRIDGE>_DESTINATION_ID in .env")
+            raise RuntimeError(
+                "No fridges configured — set at least one <FRIDGE>_PROTEOX_URL and <FRIDGE>_DESTINATION_ID in .env"
+            )
         return base

--- a/src/qubot/core/units.py
+++ b/src/qubot/core/units.py
@@ -17,12 +17,11 @@ Quantity = str  # "temperature" | "pressure" | "power" | "magnetic_field" | "flo
 # Each list is sorted descending by factor. The final entry is the smallest
 # prefix and is used as a fallback for sub-prefix values and for "0 …".
 QUANTITIES: dict[Quantity, list[tuple[float, str]]] = {
-    "temperature":    [(1.0,  "K"),   (1e-3, "mK")],
-    "pressure":       [(1e3,  "kPa"), (1.0,  "Pa")],
-    "power":          [(1.0,  "W"),   (1e-3, "mW"),  (1e-6, "μW"),
-                       (1e-9, "nW"),  (1e-12, "pW")],
-    "magnetic_field": [(1.0,  "T"),   (1e-3, "mT")],
-    "flow":           [(1.0,  "μmol/s")],
+    "temperature": [(1.0, "K"), (1e-3, "mK")],
+    "pressure": [(1e3, "kPa"), (1.0, "Pa")],
+    "power": [(1.0, "W"), (1e-3, "mW"), (1e-6, "μW"), (1e-9, "nW"), (1e-12, "pW")],
+    "magnetic_field": [(1.0, "T"), (1e-3, "mT")],
+    "flow": [(1.0, "μmol/s")],
 }
 
 

--- a/src/qubot/main.py
+++ b/src/qubot/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 # Load .env into os.environ FIRST, so the qtics module (which reads
 # WAMP_USER / WAMP_USER_SECRET / WAMP_REALM / WAMP_ROUTER_URL at import time
 # via os.getenv) sees them before any cog imports it transitively.
-from dotenv import load_dotenv  # type: ignore[import-not-found]
+from dotenv import load_dotenv
 
 load_dotenv()
 

--- a/src/qubot/services/destinations.py
+++ b/src/qubot/services/destinations.py
@@ -28,9 +28,7 @@ async def resolve(bot: discord.Client, conn: FridgeConnection) -> discord.abc.Me
     return thread
 
 
-async def send_embed(
-    bot: discord.Client, conn: FridgeConnection, embed: discord.Embed
-) -> None:
+async def send_embed(bot: discord.Client, conn: FridgeConnection, embed: discord.Embed) -> None:
     """Send an embed to the configured destination."""
     target = await resolve(bot, conn)
     await target.send(embed=embed)

--- a/src/qubot/services/proteox.py
+++ b/src/qubot/services/proteox.py
@@ -10,7 +10,7 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
-from qtics.instruments.network.proteox.proteox import Proteox  # type: ignore[import-not-found]
+from qtics.instruments.network.proteox.proteox import Proteox
 
 from qubot.core.fridge_config import FridgeProfile, SensorSpec
 from qubot.core.logging_setup import get_logger
@@ -66,9 +66,9 @@ class Snapshot:
         """(label, readings) pairs in display order. Callers skip empty ones."""
         return [
             ("Temperatures", self.temperatures),
-            ("Pressures",    self.pressures),
-            ("Heaters",      self.heaters),
-            ("Flow",         self.flow),
+            ("Pressures", self.pressures),
+            ("Heaters", self.heaters),
+            ("Flow", self.flow),
         ]
 
 
@@ -99,16 +99,12 @@ class ProteoxService:
             await asyncio.wait_for(self._client.connect(), timeout=self._CONNECT_TIMEOUT_S)
         except asyncio.TimeoutError:
             self._log.error("connection timeout to %s", self._conn.proteox_url)
-            raise RuntimeError(
-                "is not responding. Please check the network."
-            ) from None
+            raise RuntimeError("is not responding. Please check the network.") from None
         except Exception as exc:  # noqa: BLE001
             exc_str = str(exc).lower()
             if any(kw in exc_str for kw in ["timeout", "handshake", "refused", "unreachable"]):
                 self._log.error("connection error to %s: %s", self._conn.proteox_url, exc)
-                raise RuntimeError(
-                    "is not responding. Please check the network."
-                ) from None
+                raise RuntimeError("is not responding. Please check the network.") from None
             raise
         return self
 
@@ -135,6 +131,7 @@ class ProteoxService:
         return [await self._read(s) for s in specs]
 
     async def _is_local(self) -> bool:
+        assert self._client is not None
         state = await self._client.get_state()
         return state is None or "None" in str(state)
 

--- a/src/qubot/services/recognized_report.py
+++ b/src/qubot/services/recognized_report.py
@@ -13,9 +13,7 @@ COLOR_WARN = 0xF1C40F
 COLOR_FAIL = 0xE74C3C
 
 
-def build_recognized_states_embed(
-    profile: FridgeProfile, names: list[str]
-) -> discord.Embed:
+def build_recognized_states_embed(profile: FridgeProfile, names: list[str]) -> discord.Embed:
     """Static list of every recognized state in the Proteox truth table."""
     embed = discord.Embed(
         title=f"📚 **Recognized states — {profile.display_name}**",
@@ -88,9 +86,7 @@ def build_transition_plan_embed(
         title=f"🛠️ **{profile.display_name}** — Transition suggestion",
         color=profile.color,
     )
-    header = (
-        "**Closest target state**" if requested_target is None else "**Target state**"
-    )
+    header = "**Closest target state**" if requested_target is None else "**Target state**"
     embed.add_field(name=header, value=target_state, inline=True)
     if mismatch_count is not None:
         embed.add_field(name="**Mismatches**", value=str(mismatch_count), inline=True)

--- a/src/qubot/services/report.py
+++ b/src/qubot/services/report.py
@@ -30,7 +30,9 @@ def build_report_embed(profile: FridgeProfile, snap: Snapshot) -> discord.Embed:
 
     # Add resources if configured
     if profile.has_resources():
-        resources_text = "\n".join(f"- **[{link.label}]({link.url})**" for link in profile.resources)
+        resources_text = "\n".join(
+            f"- **[{link.label}]({link.url})**" for link in profile.resources
+        )
         embed.add_field(name="**RESOURCES**", value=resources_text, inline=False)
 
     return embed

--- a/src/qubot/services/uta.py
+++ b/src/qubot/services/uta.py
@@ -86,30 +86,35 @@ class UtaSnapshot:
     @property
     def any_alarm(self) -> bool:
         return bool(
-            self.termalarm or self.notifier or self.incendio
-            or self.alinverterin or self.alinverterout or self.generalarm
+            self.termalarm
+            or self.notifier
+            or self.incendio
+            or self.alinverterin
+            or self.alinverterout
+            or self.generalarm
         )
 
     @property
     def any_alarm_chiller(self) -> bool:
         return bool(
-            self.frigoalarm or self.frigotermico
-            or self.valvemerginacquedotto or self.valvemergout
+            self.frigoalarm
+            or self.frigotermico
+            or self.valvemerginacquedotto
+            or self.valvemergout
             or self.pompaalarm
         )
 
     @property
     def is_running(self) -> bool:
-        return bool(
-            self.marcia and self.inverterin and self.inverterout
-            and not self.any_alarm
-        )
+        return bool(self.marcia and self.inverterin and self.inverterout and not self.any_alarm)
 
     @property
     def chiller_running(self) -> bool:
         return bool(
-            self.frigoon and not self.valvemerginacquedotto
-            and not self.valvemergout and not self.any_alarm_chiller
+            self.frigoon
+            and not self.valvemerginacquedotto
+            and not self.valvemergout
+            and not self.any_alarm_chiller
         )
 
 
@@ -230,23 +235,45 @@ def parse_uta_html(html_text: str, tz: ZoneInfo) -> UtaSnapshot:
 
     return UtaSnapshot(
         timestamp=ts,
-        t_lab=t_lab, t_pumps_room=t_pumps_room, t_external=t_external,
-        t_water_cold=t_water_cold, t_water_hot=t_water_hot,
+        t_lab=t_lab,
+        t_pumps_room=t_pumps_room,
+        t_external=t_external,
+        t_water_cold=t_water_cold,
+        t_water_hot=t_water_hot,
         t_water_chiller=t_water_chiller,
-        t_preheat=t_preheat, sp_preheat=sp_preheat, valve_preheat=valve_preheat,
-        t_cool=t_cool, valve_cool=valve_cool,
-        t_supply=t_supply, sp_supply=sp_supply, valve_supply=valve_supply,
-        sp_summer=sp_summer, sp_winter=sp_winter,
-        flow_supply=flow_supply, flow_return=flow_return,
-        dp_pocket=dp_pocket, dp_absolute=dp_absolute,
-        humidity=humidity, co2=co2,
+        t_preheat=t_preheat,
+        sp_preheat=sp_preheat,
+        valve_preheat=valve_preheat,
+        t_cool=t_cool,
+        valve_cool=valve_cool,
+        t_supply=t_supply,
+        sp_supply=sp_supply,
+        valve_supply=valve_supply,
+        sp_summer=sp_summer,
+        sp_winter=sp_winter,
+        flow_supply=flow_supply,
+        flow_return=flow_return,
+        dp_pocket=dp_pocket,
+        dp_absolute=dp_absolute,
+        humidity=humidity,
+        co2=co2,
         stagione=season,
-        marcia=marcia, iauto=iauto, ausiliari=ausiliari,
-        inverterin=inverterin, inverterout=inverterout, fancoil=fancoil,
-        termalarm=termalarm, notifier=notifier, incendio=incendio,
-        alinverterin=alinverterin, alinverterout=alinverterout,
-        frigoon=frigoon, frigoalarm=frigoalarm, frigotermico=frigotermico,
-        valvemergout=valvemergout, valvemerginacquedotto=valvemerginacquedotto,
+        marcia=marcia,
+        iauto=iauto,
+        ausiliari=ausiliari,
+        inverterin=inverterin,
+        inverterout=inverterout,
+        fancoil=fancoil,
+        termalarm=termalarm,
+        notifier=notifier,
+        incendio=incendio,
+        alinverterin=alinverterin,
+        alinverterout=alinverterout,
+        frigoon=frigoon,
+        frigoalarm=frigoalarm,
+        frigotermico=frigotermico,
+        valvemergout=valvemergout,
+        valvemerginacquedotto=valvemerginacquedotto,
         pompaalarm=pompaalarm,
     )
 
@@ -272,6 +299,9 @@ async def fetch_uta_snapshot(settings: "Settings") -> UtaSnapshot:
     snap = parse_uta_html(html_text, ZoneInfo(settings.daily_report_tz))
     log.info(
         "snapshot ok: marcia=%s any_alarm=%s frigoon=%s any_alarm_chiller=%s",
-        snap.marcia, snap.any_alarm, snap.frigoon, snap.any_alarm_chiller,
+        snap.marcia,
+        snap.any_alarm,
+        snap.frigoon,
+        snap.any_alarm_chiller,
     )
     return snap

--- a/src/qubot/services/uta_report.py
+++ b/src/qubot/services/uta_report.py
@@ -6,8 +6,8 @@ import discord
 
 from qubot.services.uta import UtaSnapshot
 
-COLOR_OK = 0x2ECC71       # green — plant running, no alarms
-COLOR_ALARM = 0xE74C3C    # red — any active alarm
+COLOR_OK = 0x2ECC71  # green — plant running, no alarms
+COLOR_ALARM = 0xE74C3C  # red — any active alarm
 COLOR_NEUTRAL = 0x95A5A6  # grey — stopped without alarms
 
 
@@ -52,35 +52,40 @@ def _temperatures_section(snap: UtaSnapshot) -> str:
         setpoint, season_label = snap.sp_winter, "winter"
     else:
         setpoint, season_label = snap.sp_summer, "summer"
-    return "\n".join([
-        f"- **Lab**: {_f(snap.t_lab)} °C (SP {season_label}: {_f(setpoint)} °C)",
-        f"- **Pumps room**: {_f(snap.t_pumps_room)} °C",
-        f"- **External**: {_f(snap.t_external)} °C",
-        f"- **Cold water**: {_f(snap.t_water_cold)} °C",
-        f"- **Hot water**: {_f(snap.t_water_hot)} °C",
-        f"- **Pre-heat coil**: {_f(snap.t_preheat)} °C "
-        f"(SP {_f(snap.sp_preheat)} °C, valve {_f(snap.valve_preheat, 1)} %)",
-        f"- **Cooling coil**: {_f(snap.t_cool)} °C "
-        f"(valve {_f(snap.valve_cool, 1)} %)",
-        f"- **Supply duct**: {_f(snap.t_supply)} °C "
-        f"(SP {_f(snap.sp_supply)} °C, valve {_f(snap.valve_supply, 1)} %)",
-    ])
+    return "\n".join(
+        [
+            f"- **Lab**: {_f(snap.t_lab)} °C (SP {season_label}: {_f(setpoint)} °C)",
+            f"- **Pumps room**: {_f(snap.t_pumps_room)} °C",
+            f"- **External**: {_f(snap.t_external)} °C",
+            f"- **Cold water**: {_f(snap.t_water_cold)} °C",
+            f"- **Hot water**: {_f(snap.t_water_hot)} °C",
+            f"- **Pre-heat coil**: {_f(snap.t_preheat)} °C "
+            f"(SP {_f(snap.sp_preheat)} °C, valve {_f(snap.valve_preheat, 1)} %)",
+            f"- **Cooling coil**: {_f(snap.t_cool)} °C " f"(valve {_f(snap.valve_cool, 1)} %)",
+            f"- **Supply duct**: {_f(snap.t_supply)} °C "
+            f"(SP {_f(snap.sp_supply)} °C, valve {_f(snap.valve_supply, 1)} %)",
+        ]
+    )
 
 
 def _flow_section(snap: UtaSnapshot) -> str:
-    return "\n".join([
-        f"- **Supply flow**: {_f(snap.flow_supply, 1)} m³/h",
-        f"- **Return flow**: {_f(snap.flow_return, 1)} m³/h",
-        f"- **Pocket filter ΔP**: {_f(snap.dp_pocket)} Pa",
-        f"- **Absolute filter ΔP**: {_f(snap.dp_absolute)} Pa",
-    ])
+    return "\n".join(
+        [
+            f"- **Supply flow**: {_f(snap.flow_supply, 1)} m³/h",
+            f"- **Return flow**: {_f(snap.flow_return, 1)} m³/h",
+            f"- **Pocket filter ΔP**: {_f(snap.dp_pocket)} Pa",
+            f"- **Absolute filter ΔP**: {_f(snap.dp_absolute)} Pa",
+        ]
+    )
 
 
 def _air_quality_section(snap: UtaSnapshot) -> str:
-    return "\n".join([
-        f"- **Humidity**: {_f(snap.humidity, 1)} %",
-        f"- **CO₂**: {_f(snap.co2, 1)} ppm",
-    ])
+    return "\n".join(
+        [
+            f"- **Humidity**: {_f(snap.humidity, 1)} %",
+            f"- **CO₂**: {_f(snap.co2, 1)} ppm",
+        ]
+    )
 
 
 def _chiller_section(snap: UtaSnapshot) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+"""Shared fixtures and sample data for the QuBot test suite.
+
+Heavy, optional-dependency imports (anything that pulls in ``qtics`` via
+``qubot.services.proteox``) are kept *out* of this module so the pure-logic
+tests still collect even when those packages are unavailable. Such imports live
+inside the individual test modules that need them.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+# --- Sample UTA CGI HTML -----------------------------------------------------
+# Trimmed but structurally faithful renderings of what utareport_html.c emits.
+# parse_uta_html() first strips tags, so the exact markup is irrelevant — only
+# the label strings and numbers matter.
+
+UTA_HTML_RUNNING = textwrap.dedent(
+    """\
+    <html><body>
+    <p>Thu 2026-05-14 12:31:15 CEST</p>
+    <p>Impianto in marcia</p>
+    <p>Sel AUTO = 1 :: ausiliari = 0</p>
+    <p>Fancoil: ON</p>
+    <p>T laboratorio: 21.4</p>
+    <p>(SP estate 24.0)</p>
+    <p>T locale pompe: 19.2</p>
+    <p>T esterna: 27.8</p>
+    <p>T acqua fredda: 7.1</p>
+    <p>T acqua calda: 41.0</p>
+    <p>Preriscaldamento: 22.0 ( 23.0 ) 10.0</p>
+    <p>Raffreddamento: 18.5 ( x ) 40.0</p>
+    <p>Canale Mandata: 20.1 ( 21.0 ) 55.0</p>
+    <p>portata mandata 1200.0 :: ripresa 1100.0</p>
+    <p>DP filtri a tasca: 120.0</p>
+    <p>DP filtri assoluti: 80.0</p>
+    <p>Umidita: 45.0</p>
+    <p>CO2 mand: 480.0</p>
+    <p>Temperatura H2O: 6.5</p>
+    <p>Impianto H2O raffreddamento in funzione</p>
+    </body></html>
+    """
+)
+
+# Winter season, plant stopped, multiple alarms, chiller off.
+UTA_HTML_ALARM_WINTER = textwrap.dedent(
+    """\
+    <html><body>
+    <p>Mon 2026-01-12 08:05:00 CET</p>
+    <p>Impianto fermo</p>
+    <p>SP inverno</p>
+    <p>(SP inverno 20.0)</p>
+    <p>Inverter ripresa fermo</p>
+    <p>Inverter mandata fermo</p>
+    <p>Cumulativo allarme termiche</p>
+    <p>Allarme centrale NOTIFIER</p>
+    <p>Allarme inverter (ripresa: 1 :: mandata: 0)</p>
+    <p>Allarme termico gruppo frigo</p>
+    <p>Impianto H2O raffreddamento fermo</p>
+    <p>T laboratorio: 19.0</p>
+    </body></html>
+    """
+)
+
+# No recognizable timestamp and almost no fields — exercises fallbacks.
+UTA_HTML_SPARSE = "<html><body><p>nothing useful here</p></body></html>"
+
+
+@pytest.fixture
+def uta_html_running() -> str:
+    return UTA_HTML_RUNNING
+
+
+@pytest.fixture
+def uta_html_alarm_winter() -> str:
+    return UTA_HTML_ALARM_WINTER
+
+
+@pytest.fixture
+def uta_html_sparse() -> str:
+    return UTA_HTML_SPARSE

--- a/tests/test_cogs.py
+++ b/tests/test_cogs.py
@@ -1,0 +1,132 @@
+"""Light cog tests with mocked Discord / Proteox objects.
+
+These import the cog modules (and therefore ``discord`` and ``qtics``), both of
+which are installed by ``poetry install`` and in CI.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from qubot.cogs import reports, scheduler
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _conn(dest_id: int):
+    return SimpleNamespace(destination_id=dest_id)
+
+
+def _fake_bot(fridges=None, profiles=None):
+    settings = SimpleNamespace(
+        fridges=fridges or {},
+        profiles=profiles or {},
+        daily_report_tz="Europe/Rome",
+        daily_report_hour=9,
+        daily_report_minute=30,
+    )
+    return SimpleNamespace(settings=settings, profiles=profiles or {})
+
+
+class _FakeSnap:
+    def __init__(self, *, status="Running", is_idle=False, pt2=2.0):
+        self.status = status
+        self.is_idle = is_idle
+        self._pt2 = pt2
+
+    def temperature_value(self, _key):
+        return self._pt2
+
+
+def _proteox_cls_returning(snap):
+    class _FakeProteox:
+        def __init__(self, conn, profile):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def snapshot(self):
+            return snap
+
+    return _FakeProteox
+
+
+# --- ReportsCog -------------------------------------------------------------
+
+
+def test_reports_builds_channel_map():
+    bot = _fake_bot(fridges={"elsa": _conn(111), "anna": _conn(222)})
+    cog = reports.ReportsCog(bot)
+    assert cog._fridge_by_channel == {111: "elsa", 222: "anna"}
+
+
+@pytest.mark.asyncio
+async def test_report_in_unbound_channel_defers_ephemerally():
+    bot = _fake_bot(fridges={"elsa": _conn(111)})
+    cog = reports.ReportsCog(bot)
+
+    interaction = SimpleNamespace(
+        channel_id=999,  # not bound to any fridge
+        user="tester",
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    await reports.ReportsCog.report.callback(cog, interaction)
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    interaction.followup.send.assert_not_called()
+
+
+# --- SchedulerCog._maybe_post_for -------------------------------------------
+
+
+@pytest.fixture
+def scheduler_cog():
+    profile = SimpleNamespace(pt2_key="PT2_T1", display_name="Elsa")
+    bot = _fake_bot(fridges={"elsa": _conn(111)}, profiles={"elsa": profile})
+    return scheduler.SchedulerCog(bot)
+
+
+async def _run_maybe_post(monkeypatch, cog, snap):
+    send_mock = AsyncMock()
+    monkeypatch.setattr(scheduler, "ProteoxService", _proteox_cls_returning(snap))
+    monkeypatch.setattr(scheduler.destinations, "send_embed", send_mock)
+    monkeypatch.setattr(scheduler, "build_report_embed", lambda profile, snap: "EMBED")
+    await cog._maybe_post_for("elsa")
+    return send_mock
+
+
+@pytest.mark.asyncio
+async def test_skip_when_idle_and_warm(monkeypatch, scheduler_cog):
+    snap = _FakeSnap(status="Idle", is_idle=True, pt2=300.0)
+    send = await _run_maybe_post(monkeypatch, scheduler_cog, snap)
+    send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_when_running(monkeypatch, scheduler_cog):
+    snap = _FakeSnap(status="Running", is_idle=False, pt2=2.0)
+    send = await _run_maybe_post(monkeypatch, scheduler_cog, snap)
+    send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_when_idle_but_cold(monkeypatch, scheduler_cog):
+    snap = _FakeSnap(status="Idle", is_idle=True, pt2=2.0)
+    send = await _run_maybe_post(monkeypatch, scheduler_cog, snap)
+    send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_skip_when_local_mode(monkeypatch, scheduler_cog):
+    snap = _FakeSnap(status="Unknown (None)", is_idle=False, pt2=2.0)
+    send = await _run_maybe_post(monkeypatch, scheduler_cog, snap)
+    send.assert_not_called()

--- a/tests/test_fridge_config.py
+++ b/tests/test_fridge_config.py
@@ -1,0 +1,49 @@
+"""Tests for ``qubot.core.fridge_config`` — YAML profile loading + validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qubot.core.fridge_config import FridgeProfile, load_profile
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+
+
+@pytest.mark.parametrize("name", ["elsa", "anna", "olaf"])
+def test_load_real_profiles(name):
+    profile = load_profile(name, CONFIG_DIR)
+    assert profile.name == name
+    assert profile.display_name  # non-empty
+    # The scheduler's warm-fridge gate keys off PT2.
+    assert profile.pt2_key == "PT2_T1"
+    # mixing_chamber_key was removed; it must not resurface as a field.
+    assert not hasattr(profile, "mixing_chamber_key")
+    # Every fridge defines at least one temperature sensor.
+    assert profile.temperatures
+
+
+def test_pt2_key_defaults_when_omitted():
+    profile = FridgeProfile(name="x", display_name="X")
+    assert profile.pt2_key == "PT2_T1"
+
+
+def test_unknown_quantity_raises(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "display_name: Bad\n"
+        "temperatures:\n"
+        "  - { uri_key: T1, label: T1, quantity: not_a_quantity }\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="not_a_quantity"):
+        load_profile("bad", tmp_path)
+
+
+def test_load_fills_name_from_filename(tmp_path):
+    p = tmp_path / "fridgey.yaml"
+    p.write_text("display_name: Fridgey\n", encoding="utf-8")
+    profile = load_profile("fridgey", tmp_path)
+    assert profile.name == "fridgey"
+    assert profile.display_name == "Fridgey"

--- a/tests/test_proteox_snapshot.py
+++ b/tests/test_proteox_snapshot.py
@@ -1,0 +1,84 @@
+"""Tests for the pure dataclasses in ``qubot.services.proteox``.
+
+Only ``Snapshot`` and ``SensorReading`` are exercised — never the WAMP client.
+Importing this module pulls in ``qtics`` (a dependency of ``proteox``); that is
+installed by ``poetry install`` and in CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from qubot.core.fridge_config import SensorSpec
+from qubot.services.proteox import SensorReading, Snapshot
+
+
+def _reading(uri_key: str, value, quantity: str = "temperature", **kw) -> SensorReading:
+    return SensorReading(
+        spec=SensorSpec(uri_key=uri_key, label=uri_key, quantity=quantity, **kw),
+        value=value,
+    )
+
+
+# --- Snapshot.status / is_idle ----------------------------------------------
+
+
+def test_status_is_first_state():
+    assert Snapshot(fridge_name="elsa", states=["Running", "Idle"]).status == "Running"
+
+
+def test_status_unknown_when_no_states():
+    assert Snapshot(fridge_name="elsa", states=[]).status == "Unknown"
+
+
+@pytest.mark.parametrize(
+    "states,expected",
+    [
+        (["IDLE"], True),
+        (["Idle (precool)"], True),
+        (["idle"], True),
+        (["Running"], False),
+        ([], False),
+        (["Cooldown", "Idle complete"], True),
+    ],
+)
+def test_is_idle(states, expected):
+    assert Snapshot(fridge_name="elsa", states=states).is_idle is expected
+
+
+# --- Snapshot.temperature_value ---------------------------------------------
+
+
+def test_temperature_value_hit_and_miss():
+    snap = Snapshot(
+        fridge_name="elsa",
+        states=["Running"],
+        temperatures=[_reading("PT2_T1", 3.2), _reading("MC_T", 0.012)],
+    )
+    assert snap.temperature_value("PT2_T1") == 3.2
+    assert snap.temperature_value("MC_T") == 0.012
+    assert snap.temperature_value("DOES_NOT_EXIST") is None
+
+
+# --- SensorReading.formatted ------------------------------------------------
+
+
+def test_heater_zero_renders_off():
+    assert _reading("MC_H", 0, quantity="power").formatted() == "OFF"
+
+
+def test_non_heater_zero_is_out_of_range():
+    assert _reading("MC_T", 0, quantity="temperature").formatted() == "Out of range"
+
+
+def test_none_value_is_na():
+    assert _reading("MC_T", None).formatted() == "N/A"
+
+
+def test_normal_value_delegates_to_format_value():
+    # 0.9 K → 900 mK via the temperature prefix table.
+    assert _reading("MC_T", 0.9, precision=3).formatted() == "900.000 mK"
+
+
+def test_heater_nonzero_still_formats_power():
+    assert _reading("MC_H", 2.5e-3, quantity="power").formatted() == "2.500 mW"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,78 @@
+"""Tests for ``qubot.core.settings`` — env-driven loading and per-fridge skip.
+
+Each test runs in a clean temp cwd (so the repo's real ``.env`` is never picked
+up) and clears any fridge/credential env vars that might leak from the shell.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from qubot.core.settings import FRIDGE_NAMES, Settings
+
+# Env var suffixes a fully-configured fridge needs.
+_FRIDGE_SUFFIXES = ("PROTEOX_URL", "PROTEOX_REALM", "DESTINATION_ID", "DESTINATION_TYPE")
+_BASE_VARS = ("DISCORD_TOKEN", "WAMP_USER", "WAMP_USER_SECRET", "WAMP_REALM")
+
+
+@pytest.fixture
+def clean_env(monkeypatch, tmp_path):
+    """Isolate settings loading: empty cwd + no relevant env vars set."""
+    monkeypatch.chdir(tmp_path)
+    for var in _BASE_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for name in FRIDGE_NAMES:
+        for suffix in _FRIDGE_SUFFIXES:
+            monkeypatch.delenv(f"{name.upper()}_{suffix}", raising=False)
+    # Minimal top-level required fields.
+    monkeypatch.setenv("DISCORD_TOKEN", "test-token")
+    monkeypatch.setenv("WAMP_USER", "user")
+    monkeypatch.setenv("WAMP_USER_SECRET", "secret")
+    return monkeypatch
+
+
+def _configure_fridge(monkeypatch, name: str, dest_id: int, dest_type: str = "channel"):
+    up = name.upper()
+    monkeypatch.setenv(f"{up}_PROTEOX_URL", f"ws://{name}.example/ws")
+    monkeypatch.setenv(f"{up}_DESTINATION_ID", str(dest_id))
+    monkeypatch.setenv(f"{up}_DESTINATION_TYPE", dest_type)
+
+
+def test_full_fridge_is_loaded(clean_env):
+    _configure_fridge(clean_env, "elsa", 12345, "thread")
+    settings = Settings.load()
+
+    assert set(settings.fridges) == {"elsa"}
+    elsa = settings.fridges["elsa"]
+    assert elsa.destination_id == 12345
+    assert elsa.destination_type == "thread"
+    assert elsa.proteox_url == "ws://elsa.example/ws"
+    # Default realm applied.
+    assert elsa.proteox_realm == "ucss"
+
+
+def test_incomplete_fridge_is_skipped_not_fatal(clean_env):
+    # anna fully configured; elsa missing its DESTINATION_ID.
+    _configure_fridge(clean_env, "anna", 999)
+    clean_env.setenv("ELSA_PROTEOX_URL", "ws://elsa.example/ws")
+    clean_env.setenv("ELSA_DESTINATION_TYPE", "channel")
+
+    settings = Settings.load()
+
+    assert "anna" in settings.fridges
+    assert "elsa" not in settings.fridges
+
+
+def test_no_fridges_configured_raises(clean_env):
+    with pytest.raises(RuntimeError, match="No fridges configured"):
+        Settings.load()
+
+
+def test_invalid_destination_type_skips_fridge(clean_env):
+    _configure_fridge(clean_env, "olaf", 1)  # valid anchor so load() succeeds
+    _configure_fridge(clean_env, "elsa", 2, dest_type="carrier-pigeon")
+
+    settings = Settings.load()
+
+    assert "olaf" in settings.fridges
+    assert "elsa" not in settings.fridges

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -7,26 +7,36 @@ from qubot.core.units import format_value
     "raw,quantity,kwargs,expected",
     [
         # Temperature: K vs mK only.
-        (0.9,    "temperature", {}, "900.000 mK"),
-        (1.2,    "temperature", {}, "1.200 K"),
-        (1.234,  "temperature", {"precision": 2}, "1.23 K"),
+        (0.9, "temperature", {}, "900.000 mK"),
+        (1.2, "temperature", {}, "1.200 K"),
+        (1.234, "temperature", {"precision": 2}, "1.23 K"),
         # Pressure: kPa / Pa only.
-        (1500,   "pressure", {}, "1.500 kPa"),
-        (12.0,   "pressure", {}, "12.000 Pa"),
-        (500,    "pressure", {"precision": 1}, "0.5 kPa"),
+        (1500, "pressure", {}, "1.500 kPa"),
+        (12.0, "pressure", {}, "12.000 Pa"),
+        # 500 Pa keeps mantissa >= 1 in Pa, so it does not promote to kPa.
+        (500, "pressure", {"precision": 1}, "500.0 Pa"),
         # Power: full SI range.
         (1.2e-9, "power", {}, "1.200 nW"),
-        (3.4e-13,"power", {}, "0.340 pW"),
+        (3.4e-13, "power", {}, "0.340 pW"),
         (2.5e-3, "power", {}, "2.500 mW"),
         # Flow: fixed display μmol/s with from_base_scale=1e6.
-        (5e-3,   "flow", {"from_base_scale": 1e6, "precision": 2}, "5000.00 μmol/s"),
+        (5e-3, "flow", {"from_base_scale": 1e6, "precision": 2}, "5000.00 μmol/s"),
         # None (sensor read failed).
-        (None,   "temperature", {}, "N/A"),
-        (None,   "pressure", {}, "N/A"),
+        (None, "temperature", {}, "N/A"),
+        (None, "pressure", {}, "N/A"),
         # Zero (out of range).
-        (0,      "temperature", {}, "Out of range"),
-        (0,      "power", {}, "Out of range"),
-        (0.0,    "pressure", {}, "Out of range"),
+        (0, "temperature", {}, "Out of range"),
+        (0, "power", {}, "Out of range"),
+        (0.0, "pressure", {}, "Out of range"),
+        # Magnetic field: T vs mT.
+        (1.5, "magnetic_field", {}, "1.500 T"),
+        (0.02, "magnetic_field", {}, "20.000 mT"),
+        # Negative values keep their sign and scale by magnitude.
+        (-0.5, "temperature", {}, "-500.000 mK"),
+        (-2.0, "magnetic_field", {}, "-2.000 T"),
+        # Below the smallest prefix (pW) — still rendered with it (mantissa < 1).
+        (1e-14, "power", {}, "0.010 pW"),
+        (1e-14, "power", {"precision": 6}, "0.010000 pW"),
     ],
 )
 def test_format_value(raw, quantity, kwargs, expected):
@@ -36,3 +46,10 @@ def test_format_value(raw, quantity, kwargs, expected):
 def test_unknown_quantity_raises():
     with pytest.raises(ValueError):
         format_value(1.0, "bogus")
+
+
+def test_none_and_zero_short_circuit_before_unknown_quantity():
+    # None / 0 are handled before the quantity table is consulted, so an unknown
+    # quantity does not raise in those cases.
+    assert format_value(None, "bogus") == "N/A"
+    assert format_value(0, "bogus") == "Out of range"

--- a/tests/test_uta_parser.py
+++ b/tests/test_uta_parser.py
@@ -1,0 +1,162 @@
+"""Tests for the UTA CGI HTML parser (``qubot.services.uta``).
+
+``parse_uta_html`` is pure: HTML in, ``UtaSnapshot`` out. No network involved.
+"""
+
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from qubot.services.uta import UtaSnapshot, _grab, _strip_html, parse_uta_html
+
+TZ = ZoneInfo("Europe/Rome")
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def test_strip_html_removes_tags_and_unescapes_entities():
+    out = _strip_html("<p>T&nbsp;lab: 21.4 &amp; rising</p>")
+    assert "<p>" not in out
+    assert "&amp;" not in out
+    assert "21.4" in out
+
+
+def test_grab_returns_none_when_pattern_absent():
+    assert _grab(r"T laboratorio:\s*(-?\d+(?:\.\d+)?)", "nothing here") is None
+
+
+def test_grab_parses_first_match():
+    assert _grab(r"x:\s*(-?\d+(?:\.\d+)?)", "x: -3.5 y: 9") == -3.5
+
+
+# --- full parse: running plant, summer --------------------------------------
+
+
+def test_parse_running_summer(uta_html_running):
+    snap = parse_uta_html(uta_html_running, TZ)
+
+    # Timestamp parsed from the embedded date/time.
+    assert (snap.timestamp.year, snap.timestamp.month, snap.timestamp.day) == (2026, 5, 14)
+    assert snap.timestamp.hour == 12
+    assert snap.timestamp.tzinfo == TZ
+
+    # Season + setpoint routing (summer → sp_summer set, sp_winter None).
+    assert snap.stagione == 0
+    assert snap.sp_summer == 24.0
+    assert snap.sp_winter is None
+
+    # Analog grabs.
+    assert snap.t_lab == 21.4
+    assert snap.t_pumps_room == 19.2
+    assert snap.t_external == 27.8
+    assert snap.t_water_cold == 7.1
+    assert snap.t_water_hot == 41.0
+    assert (snap.t_preheat, snap.sp_preheat, snap.valve_preheat) == (22.0, 23.0, 10.0)
+    assert (snap.t_cool, snap.valve_cool) == (18.5, 40.0)
+    assert (snap.t_supply, snap.sp_supply, snap.valve_supply) == (20.1, 21.0, 55.0)
+    assert (snap.flow_supply, snap.flow_return) == (1200.0, 1100.0)
+    assert snap.dp_pocket == 120.0
+    assert snap.dp_absolute == 80.0
+    assert snap.humidity == 45.0
+    assert snap.co2 == 480.0
+    assert snap.t_water_chiller == 6.5
+
+    # Digital state.
+    assert snap.marcia == 1
+    assert snap.inverterin == 1
+    assert snap.inverterout == 1
+    assert snap.fancoil == 1
+    assert (snap.iauto, snap.ausiliari) == (1, 0)
+    assert snap.frigoon == 1
+
+    # Derived properties.
+    assert snap.any_alarm is False
+    assert snap.any_alarm_chiller is False
+    assert snap.is_running is True
+    assert snap.chiller_running is True
+
+
+# --- full parse: stopped plant with alarms, winter --------------------------
+
+
+def test_parse_alarm_winter(uta_html_alarm_winter):
+    snap = parse_uta_html(uta_html_alarm_winter, TZ)
+
+    assert snap.stagione == 1
+    assert snap.sp_winter == 20.0
+    assert snap.sp_summer is None
+
+    assert snap.marcia == 0
+    assert snap.inverterin == 0
+    assert snap.inverterout == 0
+    assert snap.termalarm == 1
+    assert snap.notifier == 1
+    assert (snap.alinverterin, snap.alinverterout) == (1, 0)
+
+    # Chiller alarm discrimination: "termico gruppo frigo" must NOT also set the
+    # plain "gruppo frigo" alarm.
+    assert snap.frigotermico == 1
+    assert snap.frigoalarm == 0
+    assert snap.frigoon == 0
+
+    assert snap.any_alarm is True
+    assert snap.any_alarm_chiller is True
+    assert snap.is_running is False
+    assert snap.chiller_running is False
+
+
+# --- sparse / fallback behaviour --------------------------------------------
+
+
+def test_parse_sparse_uses_fallbacks(uta_html_sparse):
+    snap = parse_uta_html(uta_html_sparse, TZ)
+
+    # No timestamp in the HTML → falls back to "now" in the given tz.
+    assert snap.timestamp.tzinfo == TZ
+    # Missing analog fields stay None.
+    assert snap.t_lab is None
+    assert snap.flow_supply is None
+    # Defaults: no stop-phrases means inverters/chiller read "on", plant "off".
+    assert snap.marcia == 0
+    assert snap.inverterin == 1
+    assert snap.inverterout == 1
+    assert snap.frigoon == 1
+    assert snap.is_running is False
+
+
+# --- property truth tables (constructed directly) ---------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({}, False),
+        ({"termalarm": 1}, True),
+        ({"notifier": 1}, True),
+        ({"incendio": 1}, True),
+        ({"alinverterin": 1}, True),
+        ({"generalarm": 1}, True),
+    ],
+)
+def test_any_alarm(kwargs, expected):
+    from datetime import datetime
+
+    snap = UtaSnapshot(timestamp=datetime.now(tz=TZ), **kwargs)
+    assert snap.any_alarm is expected
+
+
+def test_is_running_requires_all_three_and_no_alarm():
+    from datetime import datetime
+
+    base = dict(marcia=1, inverterin=1, inverterout=1)
+    assert UtaSnapshot(timestamp=datetime.now(tz=TZ), **base).is_running is True
+    # Any alarm disqualifies.
+    assert UtaSnapshot(timestamp=datetime.now(tz=TZ), notifier=1, **base).is_running is False
+    # Missing any component disqualifies.
+    assert (
+        UtaSnapshot(timestamp=datetime.now(tz=TZ), marcia=0, inverterin=1, inverterout=1).is_running
+        is False
+    )


### PR DESCRIPTION
Add test suite, CI, and main-branch protection

Hardens the project so new features reach `main` only through a reviewed, CI-passing PR. Adds an automated test suite, a GitHub Actions pipeline, and local pre-commit enforcement.

**Tests**

Adds a pytest suite (66 tests) covering the pure logic plus light, mocked cog tests:
- `test_uta_parser.py` — UTA CGI HTML parser: timestamp parsing + fallback, analog grabs, the `rirpresa` typo tolerance, season→setpoint routing, alarm/state phrase inference, chiller alarm discrimination, and UtaSnapshot property truth tables.
- `test_proteox_snapshot.py` — `Snapshot.status/is_idle/temperature_value` and `SensorReading.formatted` (heater `OFF`, `N/A`, `Out of range`).
- `test_fridge_config.py` — loads the real config/*.yaml, validates `pt2_key`, and rejects unknown quantities.
- `test_settings.py` — env-driven loading: full fridge, incomplete-fridge skip, zero-fridges error, invalid destination type.
- `test_cogs.py`— mocked `ReportsCog` routing/ephemeral-defer and `SchedulerCog` skip-vs-post decisions (idle+warm, running, idle+cold, LOCAL mode).
- `conftest.py` provides shared UTA HTML fixtures; `test_units.py` extended with magnetic-field, negative, and sub-prefix cases.

**Tooling**

- Added black, mypy, and pre-commit as dev dependencies with `[tool.black]` and a pragmatic `[tool.mypy]` baseline.
- `.pre-commit-config.yaml`runs trailing-whitespace/EOF/yaml checks, black, ruff, and mypy (mypy hook given the project's typed deps so it matches `poetry run mypy`).

**CI (`.github/workflows/ci.yml`)**

Runs on PRs to `main`:
- `lint` — pre-commit (ruff + black + mypy + basic hooks).
- `test (3.11) / test (3.12)` — pytest across both Python versions.

**Incidental fixes surfaced by the new checks**

- Corrected a wrong unit-test assertion (`500 Pa` renders as `500.0 Pa`, not `0.5 kPa`).
- Removed an unused `timezone` import in `monday.py`.
- Removed stale `# type: ignore` comments and added a missing `assert` in `proteox.py` for a
- Updated README (Contributing section + corrected the daily-report gating description from mixing-chamber to PT2).

**Follow-up (manual, post-merge)**

Enable branch protection on `main`: require a PR, 1 approval, dismiss stale approvals, `lint, test (3.11), test (3.12)`. (Requires the workflow to have run once so the check names
register.)

**Verification**

`pytest` (66 passed), `ruff`, `black --check`, `mypy src`, and `pre-commit run --all-files` all