### PR TITLE
Fix network error notification for scheduled reports

### DIFF
--- a/src/qubot/cogs/scheduler.py
+++ b/src/qubot/cogs/scheduler.py
@@ -60,6 +60,16 @@ class SchedulerCog(commands.Cog):
         try:
             async with ProteoxService(conn, profile) as svc:
                 snap = await svc.snapshot()
+        except RuntimeError as exc:
+            # Timeout / connection error — give users the same feedback as /report.
+            self.log.error("service error for %s: %s — posting network warning", name, exc)
+            try:
+                await destinations.send_text(
+                    self.bot, conn, f":warning: **{profile.display_name}** {exc}"
+                )
+            except Exception:  # noqa: BLE001
+                self.log.exception("failed to send network warning for %s", name)
+            return
         except Exception:  # noqa: BLE001
             self.log.exception("snapshot failed for %s — skipping post", name)
             return

--- a/src/qubot/services/destinations.py
+++ b/src/qubot/services/destinations.py
@@ -35,3 +35,12 @@ async def send_embed(
     target = await resolve(bot, conn)
     await target.send(embed=embed)
     _log.info("sent embed to %s id=%s", conn.destination_type, conn.destination_id)
+
+
+async def send_text(
+    bot: discord.Client, conn: FridgeConnection, content: str
+) -> None:
+    """Send a plain text message to the configured destination."""
+    target = await resolve(bot, conn)
+    await target.send(content)
+    _log.info("sent text to %s id=%s", conn.destination_type, conn.destination_id)


### PR DESCRIPTION
This PR fixes an issue with scheduled reports where network errors were only logged, and no message was sent.

Previously, when a network error occurred, the scheduled report silently failed without notifying the user. With this change, the bot now sends a message when a network error happens, ensuring users are informed about the failure.
