### PR TITLE
Add a UTA monitor function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,12 @@ WAMP_ROUTER_URL=ws://decs-router.lab.local:8080/ws
 UTA_CGI_URL=http://artico.mib.infn.it/cgi-bin/utareport_html
 UTA_CGI_TIMEOUT=10.0
 
+# `/uta monitor on` posts hourly warnings to Elsa's daily-report destination
+# when the chiller water temperature is at/above the max or the absolute-filter
+# ΔP is at/below the min. It runs until `/uta monitor off`. Defaults below.
+UTA_MONITOR_CHILLER_TEMP_MAX=16.0
+UTA_MONITOR_ABS_FILTER_MIN=60.0
+
 # -----------------------------------------------------------------------------
 # Per-fridge configuration
 # -----------------------------------------------------------------------------

--- a/src/qubot/cogs/help.py
+++ b/src/qubot/cogs/help.py
@@ -34,7 +34,9 @@ def _build_help_embed() -> discord.Embed:
     embed.add_field(
         name="**Everywhere**",
         value=(
-            "`/uta` — HVAC plant (UTA) status report.\n"
+            "`/uta report` — HVAC plant (UTA) status report.\n"
+            "`/uta monitor on|off` — toggle the hourly UTA watchdog "
+            "(posts warnings to Elsa's thread; runs until turned off).\n"
             "`/help` — this message."
         ),
         inline=False,

--- a/src/qubot/cogs/uta.py
+++ b/src/qubot/cogs/uta.py
@@ -1,9 +1,14 @@
-"""`/uta` slash command — HVAC plant (UTA) status report.
+"""`/uta` slash command group — HVAC plant (UTA) status report + hourly monitor.
 
-Unlike `/report`, this command is available in **every** channel/thread: there
+Unlike `/report`, `/uta report` is available in **every** channel/thread: there
 is no destination map and no channel gating. Each invocation downloads the
-two controller SQLite databases via FTP, reads the latest row, and renders a
-Discord embed.
+controller report via the legacy CGI, parses it, and renders a Discord embed.
+
+`/uta monitor on` / `/uta monitor off` toggle an hourly watchdog that checks the
+chiller water temperature and the absolute-filter ΔP. Each time a value is out of
+range (or the report can't be reached) it posts a warning into the thread where
+Elsa's daily report is sent. The monitor keeps running until `/uta monitor off`;
+its on/off state is in memory only, so it starts off after a bot restart.
 """
 
 from __future__ import annotations
@@ -12,25 +17,46 @@ from typing import TYPE_CHECKING
 
 import discord
 from discord import app_commands
-from discord.ext import commands
+from discord.ext import commands, tasks
 
 from qubot.core.logging_setup import get_logger
+from qubot.services import destinations
 from qubot.services.uta import fetch_uta_snapshot
 from qubot.services.uta_report import build_uta_embed
 
 if TYPE_CHECKING:
     from qubot.main import QuBot
 
+# Fridge whose daily-report destination receives the monitor warnings.
+MONITOR_FRIDGE = "elsa"
+
+NETWORK_WARNING = (
+    ":warning: **UTA** report is not reachable. Please check the network."
+)
+
 
 class UtaCog(commands.Cog):
+    uta = app_commands.Group(name="uta", description="UTA (HVAC) plant.")
+    monitor = app_commands.Group(
+        name="monitor", parent=uta, description="Hourly UTA health monitor."
+    )
+
     def __init__(self, bot: "QuBot") -> None:
         self.bot = bot
         self.log = get_logger("cog.uta")
+        self._monitor_enabled = False
+        self._monitor_loop = tasks.loop(hours=1)(self._check)
 
-    @app_commands.command(name="uta", description="Show UTA (HVAC) status report.")
-    async def uta(self, interaction: discord.Interaction) -> None:
+    async def cog_unload(self) -> None:
+        if self._monitor_loop.is_running():
+            self._monitor_loop.cancel()
+
+    @uta.command(name="report", description="Show UTA (HVAC) status report.")
+    async def report(self, interaction: discord.Interaction) -> None:
         self.log.info(
-            "/uta invoked by %s in channel=%s", interaction.user, interaction.channel_id
+            "/uta report invoked by %s in channel=%s",
+            interaction.user,
+            interaction.channel_id,
         )
         await interaction.response.defer(thinking=True)
         try:
@@ -46,6 +72,103 @@ class UtaCog(commands.Cog):
         await interaction.followup.send(
             embed=build_uta_embed(snap, cgi_url=self.bot.settings.uta_cgi_url)
         )
+
+    @monitor.command(name="on", description="Enable the hourly UTA monitor.")
+    async def monitor_on(self, interaction: discord.Interaction) -> None:
+        self.log.info("/uta monitor on invoked by %s", interaction.user)
+        if self.bot.settings.fridges.get(MONITOR_FRIDGE) is None:
+            await interaction.response.send_message(
+                f":x: **{MONITOR_FRIDGE.capitalize()}** has no configured "
+                "destination — cannot enable the UTA monitor.",
+                ephemeral=True,
+            )
+            return
+        if self._monitor_enabled:
+            await interaction.response.send_message(
+                ":information_source: UTA monitor is already running.",
+                ephemeral=True,
+            )
+            return
+        self._monitor_enabled = True
+        self._monitor_loop.start()
+        await interaction.response.send_message(
+            ":white_check_mark: UTA monitor **enabled** — checking hourly until "
+            "`/uta monitor off`.",
+            ephemeral=True,
+        )
+
+    @monitor.command(name="off", description="Disable the hourly UTA monitor.")
+    async def monitor_off(self, interaction: discord.Interaction) -> None:
+        self.log.info("/uta monitor off invoked by %s", interaction.user)
+        if not self._monitor_enabled:
+            await interaction.response.send_message(
+                ":information_source: UTA monitor is not running.",
+                ephemeral=True,
+            )
+            return
+        self._monitor_enabled = False
+        self._monitor_loop.cancel()
+        await interaction.response.send_message(
+            ":white_check_mark: UTA monitor **disabled**.",
+            ephemeral=True,
+        )
+
+    async def _check(self) -> None:
+        """One hourly monitor iteration. Keeps running regardless of result."""
+        settings = self.bot.settings
+        conn = settings.fridges.get(MONITOR_FRIDGE)
+        if conn is None:
+            self.log.warning(
+                "UTA monitor: %s not configured — skipping check", MONITOR_FRIDGE
+            )
+            return
+
+        try:
+            snap = await fetch_uta_snapshot(settings)
+        except Exception as exc:  # noqa: BLE001
+            self.log.error("UTA monitor: fetch failed: %s", exc)
+            await self._safe_send(conn, NETWORK_WARNING)
+            return
+
+        temp = snap.t_water_chiller
+        dp = snap.dp_absolute
+        if temp is None or dp is None:
+            self.log.error(
+                "UTA monitor: missing values (chiller=%s, abs_filter=%s)", temp, dp
+            )
+            await self._safe_send(conn, NETWORK_WARNING)
+            return
+
+        temp_max = settings.uta_monitor_chiller_temp_max
+        dp_min = settings.uta_monitor_abs_filter_min
+        faults: list[str] = []
+        if temp >= temp_max:
+            faults.append(
+                f"Chiller water temperature is {temp:.1f} °C "
+                f"(must be below {temp_max:.0f} °C)"
+            )
+        if dp <= dp_min:
+            faults.append(
+                f"Absolute filter ΔP is {dp:.1f} Pa "
+                f"(must be above {dp_min:.0f} Pa)"
+            )
+
+        if not faults:
+            self.log.info(
+                "UTA monitor ok (chiller=%.1f °C, abs_filter=%.1f Pa)", temp, dp
+            )
+            return
+
+        message = ":warning: **UTA** anomaly detected:\n" + "\n".join(
+            f"- {f}" for f in faults
+        )
+        await self._safe_send(conn, message)
+
+    async def _safe_send(self, conn, content: str) -> None:
+        try:
+            await destinations.send_text(self.bot, conn, content)
+        except Exception:  # noqa: BLE001
+            self.log.exception("UTA monitor: failed to send warning")
 
 
 async def setup(bot: "QuBot") -> None:

--- a/src/qubot/core/settings.py
+++ b/src/qubot/core/settings.py
@@ -66,6 +66,12 @@ class Settings(BaseSettings):
     uta_cgi_url: str = ""
     uta_cgi_timeout: float = 10.0
 
+    # UTA hourly monitor (`/uta monitor on`) thresholds. A warning is posted to
+    # Elsa's daily-report destination when the chiller water temperature is at or
+    # above the max, or the absolute filter ΔP is at or below the min.
+    uta_monitor_chiller_temp_max: float = 16.0  # °C — warn if at/above
+    uta_monitor_abs_filter_min: float = 60.0  # Pa — warn if at/below
+
     fridges: dict[str, FridgeConnection] = Field(default_factory=dict)
 
     @classmethod


### PR DESCRIPTION
## Summary

Turns `/uta` into a command group and adds an hourly UTA health monitor.

- `/uta report` - the existing on-demand HVAC report (unchanged behaviour, just moved under the group).
- `/uta monitor on` / `/uta monitor off` - toggle an hourly watchdog that posts warnings into Elsa's daily-report thread.

## Monitor behaviour

Every hour while enabled, the monitor checks two conditions and posts a `:warning:` naming the failing one(s):

- **Chiller water temperature** must stay **below 16 °C**.
- **Absolute filter ΔP** must stay **above 60 Pa**.

If the UTA report can't be reached (network error or missing values), it posts the standard "UTA report is not reachable" warning instead. The monitor keeps running and re-checks every hour until `/uta monitor off` - it does **not** auto-disable. State is in memory only, so it starts off after a bot restart.

## Other changes

- New configurable thresholds `UTA_MONITOR_CHILLER_TEMP_MAX` (16.0) and `UTA_MONITOR_ABS_FILTER_MIN` (60.0), documented in `.env.example`.
- `/help` updated to reflect `/uta report` and `/uta monitor on|off`.